### PR TITLE
Fix capacity panic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ export DOCKER_BUILDKIT=1
 # registry, not production(k8s.gcr.io).
 RELEASE_REGISTRY?=artifactory-kfs.habana-labs.com/k8s-infra-docker-dev/github/scheduler-plugins
 # RELEASE_VERSION?=v$(shell date +%Y%m%d)-v0.23.10
-RELEASE_VERSION?=v0.23.31
+RELEASE_VERSION?=v0.23.32
 RELEASE_IMAGE:=kube-scheduler:$(RELEASE_VERSION)
 RELEASE_CONTROLLER_IMAGE:=controller:$(RELEASE_VERSION)
 


### PR DESCRIPTION
Missing type assertion check caused panic
```
E1128 21:32:26.441513       1 runtime.go:78] Observed a panic: &runtime.TypeAssertionError{_interface:(*runtime._type)(0x1de78c0), concrete:(*runtime._type)(0x1f0f440), asserted:(*runtime._type)(0x2101ae0), missingMethod:""} (interface conversion: interface {} is cache.DeletedFinalStateUnknown, not *v1.Pod)
goroutine 287 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic({0x1e67480, 0xc00a39be00})
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x7d
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x203002})
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x75
panic({0x1e67480, 0xc00a39be00})
        /usr/local/go/src/runtime/panic.go:1038 +0x215
sigs.k8s.io/scheduler-plugins/pkg/capacityscheduling.(*CapacityScheduling).deletePod(0xc00024e180, {0x1f0f440, 0xc008868be0})
        /go/src/sigs.k8s.io/scheduler-plugins/pkg/capacityscheduling/capacity_scheduling.go:740 +0x22a
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/client-go/tools/cache/controller.go:245
k8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnDelete({0x2228540, {0x242f980, 0xc000998090}}, {0x1f0f440, 0xc008868be0})
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/client-go/tools/cache/controller.go:288 +0x64
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/client-go/tools/cache/shared_informer.go:789 +0xdf
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x7f33908f7fd8)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x67
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0006e0738, {0x23f5f60, 0xc000996480}, 0x1, 0xc00069d080)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x1, 0x3b9aca00, 0x0, 0xe0, 0xc0006e0788)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x89
k8s.io/apimachinery/pkg/util/wait.Until(...)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90
k8s.io/client-go/tools/cache.(*processorListener).run(0xc000320080)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/client-go/tools/cache/shared_informer.go:781 +0x6b
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:73 +0x5a
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:71 +0x88
panic: interface conversion: interface {} is cache.DeletedFinalStateUnknown, not *v1.Pod [recovered]
        panic: interface conversion: interface {} is cache.DeletedFinalStateUnknown, not *v1.Pod

goroutine 287 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x0, 0x0, 0x203002})
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0xd8
panic({0x1e67480, 0xc00a39be00})
        /usr/local/go/src/runtime/panic.go:1038 +0x215
sigs.k8s.io/scheduler-plugins/pkg/capacityscheduling.(*CapacityScheduling).deletePod(0xc00024e180, {0x1f0f440, 0xc008868be0})
        /go/src/sigs.k8s.io/scheduler-plugins/pkg/capacityscheduling/capacity_scheduling.go:740 +0x22a
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnDelete(...)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/client-go/tools/cache/controller.go:245
k8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnDelete({0x2228540, {0x242f980, 0xc000998090}}, {0x1f0f440, 0xc008868be0})
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/client-go/tools/cache/controller.go:288 +0x64
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/client-go/tools/cache/shared_informer.go:789 +0xdf
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x7f33908f7fd8)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x67
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0006e0738, {0x23f5f60, 0xc000996480}, 0x1, 0xc00069d080)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0x1, 0x3b9aca00, 0x0, 0xe0, 0xc0006e0788)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x89
k8s.io/apimachinery/pkg/util/wait.Until(...)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90
k8s.io/client-go/tools/cache.(*processorListener).run(0xc000320080)
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/client-go/tools/cache/shared_informer.go:781 +0x6b
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1()
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:73 +0x5a
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
        /go/src/sigs.k8s.io/scheduler-plugins/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:71 +0x88
```