### PR TITLE
Filter requested user zones from all possible zones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ export DOCKER_BUILDKIT=1
 # registry, not production(k8s.gcr.io).
 RELEASE_REGISTRY?=artifactory-kfs.habana-labs.com/k8s-infra-docker-dev/github/scheduler-plugins
 # RELEASE_VERSION?=v$(shell date +%Y%m%d)-v0.23.10
-RELEASE_VERSION?=v0.23.33
+RELEASE_VERSION?=v0.23.34
 RELEASE_IMAGE:=kube-scheduler:$(RELEASE_VERSION)
 RELEASE_CONTROLLER_IMAGE:=controller:$(RELEASE_VERSION)
 


### PR DESCRIPTION
## Description

We'll support filtering zones based on the provided label from the user.
If user provides 'zone in (a,b)' or 'zone=c', we'll calculate all the possible zones in the cluster,
then exclude all zones not in the user request. if any of the remaining zones fits, we select it, otherwise return no zone fits error.